### PR TITLE
rebuild-root: let the user decide the compression scheme

### DIFF
--- a/lib/autoproj/cli/standalone_ci.rb
+++ b/lib/autoproj/cli/standalone_ci.rb
@@ -31,7 +31,7 @@ module Autoproj
                 end
 
                 output = File.expand_path(output)
-                unless system('tar', 'czf', output, '--owner=root', '--group=root',
+                unless system('tar', 'caf', output, '--owner=root', '--group=root',
                               '.', chdir: dir)
                     raise "failed to create #{output}"
                 end


### PR DESCRIPTION
Use the 'a' option (--auto-compress), which decides what scheme to use
based on the file extension, instead of 'z'