### PR TITLE
cli: fix wrong argument type for --force in process_test_results

### DIFF
--- a/lib/autoproj/cli/main_ci.rb
+++ b/lib/autoproj/cli/main_ci.rb
@@ -52,7 +52,7 @@ module Autoproj
 
             desc 'process-test-results [ARGS]',
                  'Process test output (assumed to be in JUnit XML) through xunit-viewer'
-            option :force, desc: 're-generates existing output', default: false
+            option :force, desc: 're-generates existing output', type: :boolean, default: false
             option :xunit_viewer, desc: 'path to xunit-viewer', default: 'xunit-viewer'
             def process_test_results
                 require 'autoproj/cli/ci'


### PR DESCRIPTION
Thor started warnings about those (they won't be supported anymore
soon)