### PR TITLE
fix: update cache entries mtime during pull

### DIFF
--- a/lib/autoproj/cli/ci.rb
+++ b/lib/autoproj/cli/ci.rb
@@ -243,6 +243,11 @@ module Autoproj
                     raise PullError, "tar failed when pulling cache file for #{pkg.name}"
                 end
 
+                begin
+                    FileUtils.touch metadata_path, nocreate: true
+                    FileUtils.touch path, nocreate: true
+                rescue Errno::ENOENT # rubocop:disable Lint/SuppressedException
+                end
                 [true, fingerprint, metadata]
             end
 


### PR DESCRIPTION
I became convinced that rarely-updated but always-used cache entries
were being evicted in a 17G cache (so, unlikely to be actually
evicted by new useful stuff).

It turns out that the place where the cache entries mtime was not
enough. push_package_to_cache is not called for entries that were
pulled from the cache.

Touch the cache entries in the pull path, which is simpler and
guarantees that we won't have this happen again.