### PR TITLE
fix: explicitly cache log directories

### DIFF
--- a/lib/autoproj/cli/ci.rb
+++ b/lib/autoproj/cli/ci.rb
@@ -238,9 +238,9 @@ module Autoproj
                     return [false, fingerprint, {}]
                 end
 
-                FileUtils.mkdir_p(pkg.prefix)
-                unless system("tar", "xzf", path, chdir: pkg.prefix, out: "/dev/null")
-                    raise PullError, "tar failed when pulling cache file for #{pkg.name}"
+                extract_dir_tarball(pkg, pkg.prefix, path)
+                if File.file?("#{path}.logs")
+                    extract_dir_tarball(pkg, pkg.logdir, "#{path}.logs")
                 end
 
                 begin
@@ -251,13 +251,20 @@ module Autoproj
                 [true, fingerprint, metadata]
             end
 
+            def extract_dir_tarball(pkg, target_dir, path)
+                FileUtils.mkdir_p target_dir
+                return if system("tar", "xzf", path, chdir: target_dir, out: "/dev/null")
+
+                raise PullError, "tar failed when pulling #{target_dir} for #{pkg.name}"
+            end
+
             def push_package_to_cache(dir, pkg, metadata, force: false, memo: {})
                 fingerprint = pkg.fingerprint(memo: memo)
                 path = package_cache_path(dir, pkg, fingerprint: fingerprint, memo: memo)
-                temppath = "#{path}.#{Process.pid}.#{rand(256)}"
 
                 FileUtils.mkdir_p(File.dirname(path))
                 if force || !File.file?("#{path}.json")
+                    temppath = "#{path}.#{Process.pid}.#{rand(256)}"
                     File.open(temppath, "w") { |io| JSON.dump(metadata, io) }
                     FileUtils.mv(temppath, "#{path}.json")
                 end
@@ -268,12 +275,22 @@ module Autoproj
                     return [false, fingerprint]
                 end
 
+                create_dir_tarball(pkg, pkg.prefix, path)
+                if File.directory?(pkg.logdir)
+                    create_dir_tarball(pkg, pkg.logdir, "#{path}.logs")
+                end
+                [true, fingerprint]
+            end
+
+            def create_dir_tarball(pkg, source_dir, path)
+                temppath = "#{path}.#{Process.pid}.#{rand(256)}"
                 result = system("tar", "czf", temppath, ".",
-                                chdir: pkg.prefix, out: "/dev/null")
-                raise "tar failed when pushing cache file for #{pkg.name}" unless result
+                                chdir: source_dir, out: "/dev/null")
+                unless result
+                    raise "tar failed when caching #{source_dir} for #{pkg.name}"
+                end
 
                 FileUtils.mv(temppath, path)
-                [true, fingerprint]
             end
 
             def cleanup_build_cache(dir, size_limit)

--- a/test/autoproj/cli/ci_test.rb
+++ b/test/autoproj/cli/ci_test.rb
@@ -70,6 +70,26 @@ module Autoproj::CLI # rubocop:disable Style/ClassAndModuleChildren
 
                 @cli.cache_pull(@archive_dir)
             end
+            it "removes the cache files if parsing the metadata file failed" do
+                path = File.join(@archive_dir, @pkg.name, "TEST")
+                make_archive("a", "TEST", file_content: "archive")
+                flexmock(@pkg.autobuild, logdir: make_tmpdir)
+                make_archive("a", "TEST.logs", file_content: "archive")
+                File.write("#{path}.json", "invalid_json")
+
+                results = @cli.cache_pull(@archive_dir)
+                assert_equal(
+                    {
+                        "a" => {
+                            "cached" => false, "fingerprint" => "TEST"
+                        }
+                    }, results
+                )
+
+                refute File.exist?(path)
+                refute File.exist?("#{path}.logs")
+                refute File.exist?("#{path}.json")
+            end
             it "removes the cache files if extracting the build files failed" do
                 path = File.join(@archive_dir, @pkg.name, "TEST")
                 FileUtils.mkdir_p File.dirname(path)

--- a/test/autoproj/cli/ci_test.rb
+++ b/test/autoproj/cli/ci_test.rb
@@ -51,6 +51,25 @@ module Autoproj::CLI # rubocop:disable Style/ClassAndModuleChildren
                 @cli.cache_pull(@archive_dir)
                 assert File.mtime(path).tv_sec >= now.tv_sec
             end
+            it "separately pulls the package's cached logs" do
+                make_archive("a", "TEST")
+                # Use a mock here as cache_push calls the autoproj resolution logic
+                # (which will reset logdir)
+                flexmock(@pkg.autobuild, logdir: (logdir = make_tmpdir))
+                make_archive("a", "TEST.logs", file_content: "logs")
+                make_metadata("a", "TEST", timestamp: Time.now)
+
+                @cli.cache_pull(@archive_dir)
+                contents = File.read(File.join(logdir, "contents"))
+                assert_equal "logs", contents.strip
+            end
+            it "ignores a missing log cache" do
+                make_archive("a", "TEST")
+                flexmock(@pkg.autobuild, logdir: make_tmpdir)
+                make_metadata("a", "TEST", timestamp: Time.now)
+
+                @cli.cache_pull(@archive_dir)
+            end
             it "does not pull a package if its tests are enabled but "\
                "have never been invoked" do
                 make_archive("a", "TEST")
@@ -164,6 +183,29 @@ module Autoproj::CLI # rubocop:disable Style/ClassAndModuleChildren
                 assert_equal "prefix", File.read(
                     File.join(@archive_dir, @pkg.name, "contents")
                 )
+            end
+            it "separately pushes the package's log directory" do
+                make_prefix(File.join(@ws.prefix_dir, @pkg.name))
+                # Use a mock here as cache_push calls the autoproj resolution logic
+                # (which will reset logdir)
+                flexmock(@pkg.autobuild, logdir: make_tmpdir)
+                make_prefix(@pkg.autobuild.logdir, file_content: "logdir")
+                make_build_report(add: { "some" => "flag" }, timestamp: Time.now)
+
+                @cli.cache_push(@archive_dir)
+                assert File.exist?(File.join(@archive_dir, @pkg.name, "TEST.logs"))
+                system("tar", "xzf", "TEST.logs",
+                       chdir: File.join(@archive_dir, @pkg.name))
+                assert_equal "logdir", File.read(
+                    File.join(@archive_dir, @pkg.name, "contents")
+                )
+            end
+            it "ignores a missing log directory" do
+                make_prefix(File.join(@ws.prefix_dir, @pkg.name))
+                make_build_report(add: { "some" => "flag" }, timestamp: Time.now)
+
+                @cli.cache_push(@archive_dir)
+                refute File.exist?(File.join(@archive_dir, @pkg.name, "TEST.logs"))
             end
             it "does nothing if there is no build report" do
                 results = @cli.cache_push(@archive_dir)


### PR DESCRIPTION
CI currently relies on cached builds to contain their log files, so
that build reports can contain the logs from cached builds.

This worked by sheer luck for all packages for which the logs are
within the prefix (i.e. C++ packages), but did not for packages
that do not have an install step (e.g. Ruby packages).

This commit explicitly caches the package's log directory, and restores
it on pull