### PR TITLE
implement ci osdeps command

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,7 +10,9 @@ Metrics/AbcSize:
 Metrics/CyclomaticComplexity:
   Exclude:
   - lib/autoproj/cli/ci.rb
+  - lib/autoproj/cli/main_ci.rb
 
 Metrics/PerceivedComplexity:
   Exclude:
   - lib/autoproj/cli/ci.rb
+  - lib/autoproj/cli/main_ci.rb

--- a/test/autoproj/cli/main_ci_test.rb
+++ b/test/autoproj/cli/main_ci_test.rb
@@ -13,6 +13,93 @@ module Autoproj::CLI # rubocop:disable Style/ClassAndModuleChildren
             @cli = CI.new(@ws)
         end
 
+        def make_cache_pull(packages = {})
+            File.open(File.join(@ws.root_dir, "cache-pull.json"), "w") do |io|
+                JSON.dump(
+                    {
+                        "cache_pull_report" => {
+                            "packages" => packages
+                        }
+                    }, io
+                )
+            end
+        end
+
+        describe "#build" do
+            it "uses an existing cache pull report" do
+                report = {
+                    "pulled" => { "cached" => true }
+                }
+                make_cache_pull(report)
+                flexmock(Process)
+                    .should_receive(:exec).once
+                    .with(Gem.ruby, $PROGRAM_NAME, "build", "--interactive=f",
+                          "--progress=f", "--color=f", "--not", "pulled")
+
+                Dir.chdir(@ws.root_dir) do
+                    MainCI.start(%w[build])
+                end
+            end
+
+            it "pulls cache if --cache is passed even if a report exists" do
+                report = {
+                    "pulled" => { "cached" => true }
+                }
+                make_cache_pull
+                flexmock(MainCI)
+                    .new_instances
+                    .should_receive(:cache_pull)
+                    .with("/var/cache/autoproj", ignore: [])
+                    .and_return(report)
+
+                flexmock(Process)
+                    .should_receive(:exec).once
+                    .with(Gem.ruby, $PROGRAM_NAME, "build", "--interactive=f",
+                          "--progress=f", "--color=f", "--not", "pulled")
+
+                Dir.chdir(@ws.root_dir) do
+                    MainCI.start(%w[build --cache /var/cache/autoproj])
+                end
+            end
+        end
+
+        describe "#osdeps" do
+            it "runs osdeps with the packages that were not pulled" do
+                make_cache_pull(
+                    {
+                        "pulled" => { "cached" => true },
+                        "not_pulled" => { "cached" => false }
+                    }
+                )
+                flexmock(Process)
+                    .should_receive(:exec).once
+                    .with(Gem.ruby, $PROGRAM_NAME, "osdeps",
+                          "--interactive=f", "--progress=f", "--color=f", "not_pulled")
+                Dir.chdir(@ws.root_dir) do
+                    MainCI.start(%w[osdeps])
+                end
+            end
+
+            it "does nothing if report doesn't exist" do
+                flexmock(Process).should_receive(:exec).never
+                Dir.chdir(@ws.root_dir) do
+                    MainCI.start(%w[osdeps])
+                end
+            end
+
+            it "does nothing if there's nothing to build" do
+                make_cache_pull(
+                    {
+                        "pulled" => { "cached" => true }
+                    }
+                )
+                flexmock(Process).should_receive(:exec).never
+                Dir.chdir(@ws.root_dir) do
+                    MainCI.start(%w[osdeps])
+                end
+            end
+        end
+
         describe "#test" do
             it "filters out cached packages" do
                 report = {


### PR DESCRIPTION
Closes #19 

As mentioned in the other thread, transitive dependencies (i.e A depends on B which depends on osdeps C) are installed as expected because `autoproj osdeps` expands the selection to include all dependencies. Just like `autoproj build A` will also cause B to be built, `autoproj osdeps A` will cause osdeps from both A and B to be installed.