### PR TITLE
fix: copy logs not related to a package into the report directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ inherit_gem:
 
 inherit_from: .rubocop_todo.yml
 
+AllCops:
+  TargetRubyVersion: 2.5
+
 Naming/FileName:
   Exclude:
     - lib/autoproj-ci.rb

--- a/lib/autoproj/cli/ci.rb
+++ b/lib/autoproj/cli/ci.rb
@@ -194,6 +194,8 @@ module Autoproj
                     glob = Dir.glob(File.join(pkg.logdir, "*"))
                     FileUtils.cp_r(glob, logs) if File.directory?(pkg.logdir)
                 end
+
+                FileUtils.cp_r ws.log_dir, File.join(logs, "autoproj")
             end
 
             def package_cache_path(dir, pkg, fingerprint: nil, memo: {})

--- a/test/autoproj/cli/ci_test.rb
+++ b/test/autoproj/cli/ci_test.rb
@@ -8,6 +8,7 @@ module Autoproj::CLI # rubocop:disable Style/ClassAndModuleChildren
     describe CI do
         before do
             @ws = ws_create
+            FileUtils.mkdir_p @ws.log_dir
             @archive_dir = make_tmpdir
             @prefix_dir = make_tmpdir
 


### PR DESCRIPTION
This includes osdeps and configuration import logs, which are saved
in the workspace's log directory.