### PR TITLE
Add option to allow ignoring packages with failed tests on cache push

### DIFF
--- a/lib/autoproj/cli/ci.rb
+++ b/lib/autoproj/cli/ci.rb
@@ -74,7 +74,7 @@ module Autoproj
                 results
             end
 
-            def cache_push(dir)
+            def cache_push(dir, ignore_failed_tests: false)
                 packages = resolve_packages
                 metadata = consolidated_report["packages"]
 
@@ -91,6 +91,12 @@ module Autoproj
                         next
                     elsif !build_info["success"]
                         pkg.message "%s: build failed, not pushing", :magenta
+                        next
+                    elsif ignore_failed_tests &&
+                          pkg_metadata["test"] &&
+                          pkg_metadata["test"]["invoked"] &&
+                          !pkg_metadata["test"]["success"]
+                        pkg.message "%s: test failed, not pushing", :magenta
                         next
                     end
 

--- a/lib/autoproj/cli/main_ci.rb
+++ b/lib/autoproj/cli/main_ci.rb
@@ -200,6 +200,8 @@ module Autoproj
                  "cache-pull"
             option :report, type: "string", default: "cache-push.json",
                             desc: "a file which describes what has been done"
+            option :ignore_failed_tests, type: "boolean", default: false,
+                                         desc: "ignore packages with failed tests"
             def cache_push(dir)
                 dir = File.expand_path(dir)
 


### PR DESCRIPTION
This is convenient for the CI when tests sometimes fail for random reasons (i.e network issues)