### PR TITLE
fix: make sure the root of created tarball artifacts are go+rx

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "autoproj", git: "https://github.com/rock-core/autoproj"
 group :vscode do
     gem "debase", ">= 0.2.2.beta10"
+    gem "ffi", "<= 1.16.3"
     gem "pry"
     gem "pry-byebug"
     gem "rubocop"

--- a/lib/autoproj/cli/ci.rb
+++ b/lib/autoproj/cli/ci.rb
@@ -341,8 +341,10 @@ module Autoproj
                     total_size -= stat.size
                 end
 
-                Autoproj.message format("current build cache size: %.1f GB",
-                                        Float(total_size) / 1_000_000_000)
+                Autoproj.message(
+                    format("current build cache size: %<size>.1f GB",
+                           size: Float(total_size) / 1_000_000_000)
+                )
                 total_size
             end
 

--- a/lib/autoproj/cli/main_ci.rb
+++ b/lib/autoproj/cli/main_ci.rb
@@ -177,7 +177,7 @@ module Autoproj
 
                 # options[:ignore] is not set if we call from another
                 # command, e.g. build
-                ignore += (options.delete(:ignore) || [])
+                ignore += options.delete(:ignore) || []
                 results = cli.cache_pull(*dir, ignore: ignore)
 
                 if report && !report.empty?

--- a/lib/autoproj/cli/standalone_ci.rb
+++ b/lib/autoproj/cli/standalone_ci.rb
@@ -19,6 +19,8 @@ module Autoproj
                    type: :string, default: nil
             def rebuild_root(config_dir, cache_root, output)
                 dir = Dir.mktmpdir
+                FileUtils.chmod 0755, dir
+
                 Autoproj::CI::Rebuild.prepare_synthetic_buildroot(
                     File.join(config_dir, "installation-manifest"),
                     File.join(config_dir, "versions.yml"),

--- a/lib/autoproj/cli/standalone_ci.rb
+++ b/lib/autoproj/cli/standalone_ci.rb
@@ -19,7 +19,7 @@ module Autoproj
                    type: :string, default: nil
             def rebuild_root(config_dir, cache_root, output)
                 dir = Dir.mktmpdir
-                FileUtils.chmod 0755, dir
+                FileUtils.chmod 0o755, dir
 
                 Autoproj::CI::Rebuild.prepare_synthetic_buildroot(
                     File.join(config_dir, "installation-manifest"),

--- a/test/autoproj/cli/ci_test.rb
+++ b/test/autoproj/cli/ci_test.rb
@@ -495,10 +495,10 @@ module Autoproj::CLI # rubocop:disable Style/ClassAndModuleChildren
             end
 
             consolidated_report_single_behavior(
-                "import", report_path_accessor: ->(ws) { ws.import_report_path }
+                "import", report_path_accessor: lambda(&:import_report_path)
             )
             consolidated_report_single_behavior(
-                "build", report_path_accessor: ->(ws) { ws.build_report_path }
+                "build", report_path_accessor: lambda(&:build_report_path)
             )
             consolidated_report_single_behavior(
                 "test", report_path_accessor: ->(ws) { ws.utility_report_path("test") }

--- a/test/autoproj/cli/standalone_ci_test.rb
+++ b/test/autoproj/cli/standalone_ci_test.rb
@@ -35,7 +35,7 @@ module Autoproj::CLI # rubocop:disable Style/ClassAndModuleChildren
                 StandaloneCI.start(["rebuild-root", @fixtures_path, @cache_root, output])
 
                 contents = `tar tvf "#{output}"`.split("\n").map(&:strip)
-                root_folder = contents.find { %r{\./$}.match?(_1) }
+                root_folder = contents.find { |line| %r{\./$}.match?(line) }
                 assert root_folder, "cannot find the root folder in created tarball"
                 assert root_folder.start_with?("drwxr-xr-x"),
                        "expected #{root_folder} to have r-x permission for group and user"

--- a/test/autoproj/cli/standalone_ci_test.rb
+++ b/test/autoproj/cli/standalone_ci_test.rb
@@ -30,6 +30,17 @@ module Autoproj::CLI # rubocop:disable Style/ClassAndModuleChildren
                 assert File.file?(iodrivers_base_file)
             end
 
+            it "sets the tarball's root folder permissions to be 0755" do
+                output = File.join(make_tmpdir, "output.tar.gz")
+                StandaloneCI.start(["rebuild-root", @fixtures_path, @cache_root, output])
+
+                contents = `tar tvf "#{output}"`.split("\n").map(&:strip)
+                root_folder = contents.find { %r{\./$}.match?(_1) }
+                assert root_folder, "cannot find the root folder in created tarball"
+                assert root_folder.start_with?("drwxr-xr-x"),
+                       "expected #{root_folder} to have r-x permission for group and user"
+            end
+
             it "handles relative paths" do
                 out_dir = make_tmpdir
                 output = "output.tar.gz"


### PR DESCRIPTION
The code is using mktmpdir to create the folder, which makes it 0700. The resulting tarball has a root folder with the same permissions, which breaks a system for all users except root when unpacked.